### PR TITLE
Fix compiling issue for macos

### DIFF
--- a/lib/WALASupport/InstrKindInfoGetter.cpp
+++ b/lib/WALASupport/InstrKindInfoGetter.cpp
@@ -236,7 +236,7 @@ jobject InstrKindInfoGetter::handleIntegerLiteralInst() {
       Node = (*wala)->makeConstant(static_cast<int>(Value.getSExtValue()));
     }
     else if (Value.getMinSignedBits() <= 64) {
-      Node = (*wala)->makeConstant(Value.getSExtValue());
+      Node = (*wala)->makeConstant(static_cast<long>(Value.getSExtValue()));
     }
   }
   else {


### PR DESCRIPTION
This fixes the issue when compiler can not find correct makeConstant function call because makeConstant(int64_t) is not defined.