### PR TITLE
Translate SIL to WALA-IR after canonical SIL is fully generated [WIP]

### DIFF
--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -807,11 +807,6 @@ static bool performCompile(CompilerInstance &Instance,
     }
   }
 
-  // WALAWalker Integration
-  WALAWalker ww;
-  ww.analyzeSILModule(*SM);
-  // End WALAWalker Integration
-
   if (observer) {
     observer->performedSILGeneration(*SM);
   }
@@ -1003,6 +998,11 @@ static bool performCompile(CompilerInstance &Instance,
 
   assert(Action >= FrontendOptions::ActionType::EmitSIL &&
          "All actions not requiring SILPasses must have been handled!");
+
+  // WALAWalker Integration
+  WALAWalker ww;
+  ww.analyzeSILModule(*SM);
+  // End WALAWalker Integration
 
   // We've been told to write canonical SIL, so write it now.
   if (Action == FrontendOptions::ActionType::EmitSIL) {


### PR DESCRIPTION
Current SIL instructions captured by `WALAWalker` are not the final version. We should move the WALAWalker to the place where SIL instructions are fully optimized.