### PR TITLE
Fix DebugValueInst Seg Fault

### DIFF
--- a/lib/WALASupport/InstrKindInfoGetter.cpp
+++ b/lib/WALASupport/InstrKindInfoGetter.cpp
@@ -396,12 +396,7 @@ jobject InstrKindInfoGetter::handleDebugValueInst() {
     void *addr = val.getOpaqueValue();
 
     if (addr) {
-
-        // TODO: why does this line cause the segfault?
-        // argument should be safe, parentBB should be safe, argNo > 0.
-//         argument = parentBB->getArgument(argNo - 1);
-
-        // variable declaration
+      // add variable to symbol table
       symbolTable->insert(addr, varName);
       if (val) {
         *outs << "\t[addr of arg]:" << addr << "\n";
@@ -422,15 +417,6 @@ jobject InstrKindInfoGetter::handleDebugValueInst() {
     return nullptr;
   }
   
-/*
-  if (outs) {
-      SILValue val = castInst->getOperand();
-      if (val) {
-        *outs << "\t\t[addr of arg]:" << val.getOpaqueValue() << "\n";
-      }
-  }
-*/
-
   return nullptr;
 }
 

--- a/lib/WALASupport/InstrKindInfoGetter.cpp
+++ b/lib/WALASupport/InstrKindInfoGetter.cpp
@@ -385,24 +385,33 @@ jobject InstrKindInfoGetter::handleDebugValueInst() {
       return nullptr;
     }
     
-    SILBasicBlock *parentBB = nullptr;
-    parentBB = castInst->getParent();
+    SILValue val = castInst->getOperand();
+    if (!val) {
+      if (outs) {
+        *outs << "\t Operand is null\n";
+      }
+      return nullptr;
+    }
     
-    SILArgument *argument = nullptr;
+    void *addr = val.getOpaqueValue();
 
-    if (argNo >= 1 && parentBB) {
+    if (argNo >= 1 && addr) {
 
         // TODO: why does this line cause the segfault?
         // argument should be safe, parentBB should be safe, argNo > 0.
 //         argument = parentBB->getArgument(argNo - 1);
 
         // variable declaration
-        symbolTable->insert(argument, varName);
+        symbolTable->insert(addr, varName);
       }
 
-    if (outs && argument) {
-      *outs << "\t\t[addr of arg]:" << argument << "\n";
+    
+  }
+  else{
+    if (outs) {
+      *outs << "\tDecl not found\n";
     }
+    return nullptr;
   }
   
   if (outs) {

--- a/lib/WALASupport/InstrKindInfoGetter.cpp
+++ b/lib/WALASupport/InstrKindInfoGetter.cpp
@@ -927,7 +927,6 @@ SILInstructionKind InstrKindInfoGetter::get() {
     
     case SILInstructionKind::DebugValueInst: {
       node = handleDebugValueInst();
-      *outs << "<< DebugValueInstInst Broken >>" << "\n";
       break;
     }
     

--- a/lib/WALASupport/InstrKindInfoGetter.cpp
+++ b/lib/WALASupport/InstrKindInfoGetter.cpp
@@ -395,16 +395,24 @@ jobject InstrKindInfoGetter::handleDebugValueInst() {
     
     void *addr = val.getOpaqueValue();
 
-    if (argNo >= 1 && addr) {
+    if (addr) {
 
         // TODO: why does this line cause the segfault?
         // argument should be safe, parentBB should be safe, argNo > 0.
 //         argument = parentBB->getArgument(argNo - 1);
 
         // variable declaration
-        symbolTable->insert(addr, varName);
+      symbolTable->insert(addr, varName);
+      if (val) {
+        *outs << "\t[addr of arg]:" << addr << "\n";
       }
-
+    }
+    else {
+      if (outs) {
+          *outs << "\t Operand OpaqueValue is null\n";
+      }
+      return nullptr;
+    }
     
   }
   else{
@@ -414,12 +422,14 @@ jobject InstrKindInfoGetter::handleDebugValueInst() {
     return nullptr;
   }
   
+/*
   if (outs) {
       SILValue val = castInst->getOperand();
       if (val) {
         *outs << "\t\t[addr of arg]:" << val.getOpaqueValue() << "\n";
       }
   }
+*/
 
   return nullptr;
 }


### PR DESCRIPTION
Issue #10 

Seg fault due to some functions has $error as variable that isn't on the argument list

For swift code:
```
func testFunc(param1 : Int) {
	let a = 1
	let b = a + param1
}

testFunc(param1: 2)
```

Result:
```
SILFunction: 0x6a67420
// main
sil @main : $@convention(c) (Int32, UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>) -> Int32 {
bb0(%0 : $Int32, %1 : $UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>):
  %2 = metatype $@thin Int.Type                   // user: %5 line:6:18
  %3 = integer_literal $Builtin.Int2048, 2        // user: %5 line:6:18
  // function_ref Int.init(_builtinIntegerLiteral:)
  %4 = function_ref @_T0Si22_builtinIntegerLiteralSiBi2048__tcfC : $@convention(method) (Builtin.Int2048, @thin Int.Type) -> Int // user: %5 line:6:18
  %5 = apply %4(%3, %2) : $@convention(method) (Builtin.Int2048, @thin Int.Type) -> Int // user: %7 line:6:18
  // function_ref testFunc(param1:)
  %6 = function_ref @_T011simpleDebug8testFunc6param1ySi_tF : $@convention(thin) (Int) -> () // user: %7 line:6:1
  %7 = apply %6(%5) : $@convention(thin) (Int) -> () // line:6:1
  %8 = integer_literal $Builtin.Int32, 0          // user: %9 top_level
  %9 = struct $Int32 (%8 : $Builtin.Int32)        // user: %10 top_level
  return %9 : $Int32                              // id: %10 top_level
} // end sil function 'main'

Basic Block: 0x6a67548
SILFunctions: 0x6a67420
address of instr below me: 0x6a77860
<< MetatypeInst >>
  %2 = metatype $@thin Int.Type                   // user: %5

address of instr below me: 0x6baf790
<< IntegerLiteralInst >>
<< IntegerLiteralInst >>
  %3 = integer_literal $Builtin.Int2048, 2        // user: %5

address of instr below me: 0x6a778d0
<< FunctionRefInst >>
=== [FUNC] Ref'd: Swift.Int.init(_builtinIntegerLiteral: Builtin.Int2048) -> Swift.Int
  // function_ref Int.init(_builtinIntegerLiteral:)
  %4 = function_ref @_T0Si22_builtinIntegerLiteralSiBi2048__tcfC : $@convention(method) (Builtin.Int2048, @thin Int.Type) -> Int // user: %5

address of instr below me: 0x6baf900
<< ApplyInst Fails >>
  %5 = apply %4(%3, %2) : $@convention(method) (Builtin.Int2048, @thin Int.Type) -> Int // user: %7

address of instr below me: 0x6a77940
<< FunctionRefInst >>
=== [FUNC] Ref'd: simpleDebug.testFunc(param1: Swift.Int) -> ()
  // function_ref testFunc(param1:)
  %6 = function_ref @_T011simpleDebug8testFunc6param1ySi_tF : $@convention(thin) (Int) -> () // user: %7

address of instr below me: 0x6baf680
<< ApplyInst Fails >>
  %7 = apply %6(%5) : $@convention(thin) (Int) -> ()

address of instr below me: 0x6bbbb80
<< IntegerLiteralInst >>
<< IntegerLiteralInst >>
  %8 = integer_literal $Builtin.Int32, 0          // user: %9

address of instr below me: 0x6baf9f0
<< StructInst >>
  %9 = struct $Int32 (%8 : $Builtin.Int32)        // user: %10

address of instr below me: 0x6bbbbf0
<< ReturnInst >>
operand:  %9 = struct $Int32 (%8 : $Builtin.Int32)        // user: %10

addr:0x6bafa38
  return %9 : $Int32                              // id: %10

SILFunction: 0x6a676d8
// testFunc(param1:)
sil hidden @_T011simpleDebug8testFunc6param1ySi_tF : $@convention(thin) (Int) -> () {
// %0                                             // users: %9, %1
bb0(%0 : $Int):
  debug_value %0 : $Int, let, name "param1", argno 1 // id: %1 line:1:15:in_prologue
  %2 = metatype $@thin Int.Type                   // user: %5 line:2:10
  %3 = integer_literal $Builtin.Int2048, 1        // user: %5 line:2:10
  // function_ref Int.init(_builtinIntegerLiteral:)
  %4 = function_ref @_T0Si22_builtinIntegerLiteralSiBi2048__tcfC : $@convention(method) (Builtin.Int2048, @thin Int.Type) -> Int // user: %5 line:2:10
  %5 = apply %4(%3, %2) : $@convention(method) (Builtin.Int2048, @thin Int.Type) -> Int // users: %9, %6 line:2:10
  debug_value %5 : $Int, let, name "a"            // id: %6 line:2:6:in_prologue
  %7 = metatype $@thin Int.Type                   // user: %9 line:3:12
  // function_ref static Int.+ infix(_:_:)
  %8 = function_ref @_T0Si1poiyS2i_SitFZ : $@convention(method) (Int, Int, @thin Int.Type) -> Int // user: %9 line:3:12
  %9 = apply %8(%5, %0, %7) : $@convention(method) (Int, Int, @thin Int.Type) -> Int // user: %10 line:3:12
  debug_value %9 : $Int, let, name "b"            // id: %10 line:3:6:in_prologue
  %11 = tuple ()                                  // user: %12 line:4:1:cleanup
  return %11 : $()                                // id: %12 line:4:1:imp_return
} // end sil function '_T011simpleDebug8testFunc6param1ySi_tF'

Basic Block: 0x6a67830
SILFunctions: 0x6a676d8
address of instr below me: 0x6bac580
<< DebugValueInst >>
argNo: 1
	[addr of arg]:0x6a67878
  debug_value %0 : $Int, let, name "param1", argno 1 // id: %1

address of instr below me: 0x6a62d80
<< MetatypeInst >>
  %2 = metatype $@thin Int.Type                   // user: %5

address of instr below me: 0x6b8cca0
<< IntegerLiteralInst >>
<< IntegerLiteralInst >>
  %3 = integer_literal $Builtin.Int2048, 1        // user: %5

address of instr below me: 0x6aa9ba0
<< FunctionRefInst >>
=== [FUNC] Ref'd: Swift.Int.init(_builtinIntegerLiteral: Builtin.Int2048) -> Swift.Int
  // function_ref Int.init(_builtinIntegerLiteral:)
  %4 = function_ref @_T0Si22_builtinIntegerLiteralSiBi2048__tcfC : $@convention(method) (Builtin.Int2048, @thin Int.Type) -> Int // user: %5

address of instr below me: 0x6a68a40
<< ApplyInst Fails >>
  %5 = apply %4(%3, %2) : $@convention(method) (Builtin.Int2048, @thin Int.Type) -> Int // users: %9, %6

address of instr below me: 0x6aa9c10
<< DebugValueInst >>
argNo: 0
	[addr of arg]:0x6a68a88
  debug_value %5 : $Int, let, name "a"            // id: %6

address of instr below me: 0x6a68b30
<< MetatypeInst >>
  %7 = metatype $@thin Int.Type                   // user: %9

address of instr below me: 0x6a68ba0
<< FunctionRefInst >>
=== [FUNC] Ref'd: static Swift.Int.+ infix(Swift.Int, Swift.Int) -> Swift.Int
  // function_ref static Int.+ infix(_:_:)
  %8 = function_ref @_T0Si1poiyS2i_SitFZ : $@convention(method) (Int, Int, @thin Int.Type) -> Int // user: %9

address of instr below me: 0x6a96900
<< ApplyInst Fails >>
  %9 = apply %8(%5, %0, %7) : $@convention(method) (Int, Int, @thin Int.Type) -> Int // user: %10

address of instr below me: 0x6a96a10
<< DebugValueInst >>
argNo: 0
	[addr of arg]:0x6a96948
  debug_value %9 : $Int, let, name "b"            // id: %10

address of instr below me: 0x6bad500
<< TupleInst >>
  %11 = tuple ()                                  // user: %12

address of instr below me: 0x6bad570
<< ReturnInst >>
operand:  %11 = tuple ()                                  // user: %12

addr:0x6bad548
  return %11 : $()                                // id: %12

SILFunction: 0x6a67958
// Int.init(_builtinIntegerLiteral:)
sil [transparent] [serialized] @_T0Si22_builtinIntegerLiteralSiBi2048__tcfC : $@convention(method) (Builtin.Int2048, @thin Int.Type) -> Int

SILFunction: 0x6a67ac0
// static Int.+ infix(_:_:)
sil [transparent] [serialized] @_T0Si1poiyS2i_SitFZ : $@convention(method) (Int, Int, @thin Int.Type) -> Int

FOO: simpleDebug.swift
FOO: CAstValue: 3.7
FOO: simpleDebug.swift@[6:18]->[6:18]
FOO: simpleDebug.swift@[6:18]->[6:18]
FOO: simpleDebug.swift@[6:18]->[6:18]
FOO: simpleDebug.swift@[6:18]->[6:18]
FOO: simpleDebug.swift@[6:1]->[6:1]
FOO: simpleDebug.swift@[6:1]->[6:19]
FOO: simpleDebug.swift@[6:1]->[6:19]
FOO: simpleDebug.swift@[6:1]->[6:19]
FOO: simpleDebug.swift@[6:1]->[6:19]
FOO: 685325104:BLOCK
  LABEL_STMT
    "BLOCK #0"
    "2"
  "0"
  RETURN

FOO: simpleDebug.swift@[1:15]->[1:24]
FOO: simpleDebug.swift@[2:10]->[2:10]
FOO: simpleDebug.swift@[2:10]->[2:10]
FOO: simpleDebug.swift@[2:10]->[2:10]
FOO: simpleDebug.swift@[2:10]->[2:10]
FOO: simpleDebug.swift@[2:6]->[2:6]
FOO: simpleDebug.swift@[3:12]->[3:12]
FOO: simpleDebug.swift@[3:12]->[3:12]
FOO: simpleDebug.swift@[3:10]->[3:14]
FOO: simpleDebug.swift@[3:6]->[3:6]
FOO: simpleDebug.swift@[1:1]->[4:1]
FOO: simpleDebug.swift@[1:1]->[4:1]
FOO: 460141958:BLOCK
  LABEL_STMT
    "BLOCK #0"
    "1"
  RETURN
```