### PR TITLE
Fix alloc_box crash

### DIFF
--- a/lib/WALASupport/SILWalaInstructionVisitor.cpp
+++ b/lib/WALASupport/SILWalaInstructionVisitor.cpp
@@ -274,18 +274,19 @@ jobject SILWalaInstructionVisitor::visitAllocBoxInst(AllocBoxInst *ABI) {
   SILDebugVariable Info = ABI->getVarInfo();
   unsigned ArgNo = Info.ArgNo;
 
-  VarDecl *Decl = ABI->getDecl();
-
-  // getDecl() is sometimes returning nullptr, which is causing segfaults
-  // when decl is not checked before referencing.
-
-  // TODO: handle for null condition!
-  if (Decl) {
+  if (auto *Decl = ABI->getDecl()) {
     StringRef varName = Decl->getNameStr();
     if (Print) {
       llvm::outs() << "[Arg]#" << ArgNo << ":" << varName << "\n";
     }
     SymbolTable.insert(ABI, varName);
+  }
+  else {
+    // temporary allocation when referencing self.
+    if (Print) {
+      llvm::outs() << "[Arg]#" << ArgNo << ":" << "self" << "\n";
+    }
+    SymbolTable.insert(ABI, "self");
   }
   return nullptr;
 }


### PR DESCRIPTION
`VarDecl*` is null if AllocBoxInst is a temporary allocation. This is the only case when `self` is referenced. This fixes #12 