### PR TITLE
alloc_existential_box & project_existential_box

### DIFF
--- a/include/swift/WALASupport/SILWalaInstructionVisitor.h
+++ b/include/swift/WALASupport/SILWalaInstructionVisitor.h
@@ -31,6 +31,7 @@ public:
   jobject visitStringLiteralInst(StringLiteralInst *SLI);
   jobject visitConstStringLiteralInst(ConstStringLiteralInst *CSLI);
   jobject visitProjectBoxInst(ProjectBoxInst *PBI);
+  jobject visitProjectExistentialBoxInst(ProjectExistentialBoxInst *PEBI);
   jobject visitDebugValueInst(DebugValueInst *DBI);
   jobject visitFunctionRefInst(FunctionRefInst *FRI);
   jobject visitLoadInst(LoadInst *LI);

--- a/include/swift/WALASupport/SILWalaInstructionVisitor.h
+++ b/include/swift/WALASupport/SILWalaInstructionVisitor.h
@@ -26,6 +26,7 @@ public:
 
   jobject visitApplyInst(ApplyInst *AI);
   jobject visitAllocBoxInst(AllocBoxInst *ABI);
+  jobject visitAllocExistentialBoxInst(AllocExistentialBoxInst *AEBI);
   jobject visitIntegerLiteralInst(IntegerLiteralInst *ILI);
   jobject visitStringLiteralInst(StringLiteralInst *SLI);
   jobject visitConstStringLiteralInst(ConstStringLiteralInst *CSLI);

--- a/lib/WALASupport/SILWalaInstructionVisitor.cpp
+++ b/lib/WALASupport/SILWalaInstructionVisitor.cpp
@@ -300,7 +300,7 @@ jobject SILWalaInstructionVisitor::visitAllocExistentialBoxInst(AllocExistential
 
     auto name = "ExistentialBox:" + 
       AEBI->getFormalConcreteType().getString() + "->" + AEBI->getExistentialType().getAsString();
-    SymbolTable.insert(AEBI, name);
+    SymbolTable.insert(((char *)AEBI) + 0x48 , name);
 
     return nullptr;
 }
@@ -455,7 +455,7 @@ jobject SILWalaInstructionVisitor::visitProjectExistentialBoxInst(ProjectExisten
     llvm::outs() << "Operand addr " << PEBI->getOperand().getOpaqueValue() << "\n";
   }
   if (SymbolTable.has(PEBI->getOperand().getOpaqueValue())) {
-    SymbolTable.duplicate(PEBI, SymbolTable.get(PEBI->getOperand().getOpaqueValue()).c_str());
+    SymbolTable.duplicate(((char *)PEBI) + 0x48, SymbolTable.get(PEBI->getOperand().getOpaqueValue()).c_str());
   }
 
   return nullptr;

--- a/lib/WALASupport/SILWalaInstructionVisitor.cpp
+++ b/lib/WALASupport/SILWalaInstructionVisitor.cpp
@@ -291,6 +291,19 @@ jobject SILWalaInstructionVisitor::visitAllocBoxInst(AllocBoxInst *ABI) {
   return nullptr;
 }
 
+jobject SILWalaInstructionVisitor::visitAllocExistentialBoxInst(AllocExistentialBoxInst *AEBI) {    
+    if (Print) {
+      llvm::outs() << "\tConcreteType " << AEBI->getFormalConcreteType() << "\n";
+      llvm::outs() << "\tExistentialType " << AEBI->getExistentialType() << "\n";
+    }
+
+    auto name = "ExistentialBox:" + 
+      AEBI->getFormalConcreteType().getString() + "->" + AEBI->getExistentialType().getAsString();
+    SymbolTable.insert(AEBI, name);
+
+    return nullptr;
+}
+
 jobject SILWalaInstructionVisitor::visitIntegerLiteralInst(IntegerLiteralInst *ILI) {
   APInt Value = ILI->getValue();
   jobject Node = nullptr;

--- a/lib/WALASupport/SILWalaInstructionVisitor.cpp
+++ b/lib/WALASupport/SILWalaInstructionVisitor.cpp
@@ -293,6 +293,7 @@ jobject SILWalaInstructionVisitor::visitAllocBoxInst(AllocBoxInst *ABI) {
 
 jobject SILWalaInstructionVisitor::visitAllocExistentialBoxInst(AllocExistentialBoxInst *AEBI) {    
     if (Print) {
+      llvm::outs() << "AEBI " << AEBI << "\n";
       llvm::outs() << "\tConcreteType " << AEBI->getFormalConcreteType() << "\n";
       llvm::outs() << "\tExistentialType " << AEBI->getExistentialType() << "\n";
     }
@@ -446,6 +447,20 @@ jobject SILWalaInstructionVisitor::visitProjectBoxInst(ProjectBoxInst *PBI) {
   }
   return nullptr;
 }
+
+jobject SILWalaInstructionVisitor::visitProjectExistentialBoxInst(ProjectExistentialBoxInst *PEBI) {
+  if (Print) {
+    llvm::outs() << "PEBI " << PEBI << "\n";
+    llvm::outs() << "Operand " << PEBI->getOperand() << "\n";
+    llvm::outs() << "Operand addr " << PEBI->getOperand().getOpaqueValue() << "\n";
+  }
+  if (SymbolTable.has(PEBI->getOperand().getOpaqueValue())) {
+    SymbolTable.duplicate(PEBI, SymbolTable.get(PEBI->getOperand().getOpaqueValue()).c_str());
+  }
+
+  return nullptr;
+}
+
 
 jobject SILWalaInstructionVisitor::visitDebugValueInst(DebugValueInst *DBI) {
   SILDebugVariable Info = DBI->getVarInfo();

--- a/lib/WALASupport/SILWalaInstructionVisitor.cpp
+++ b/lib/WALASupport/SILWalaInstructionVisitor.cpp
@@ -300,7 +300,7 @@ jobject SILWalaInstructionVisitor::visitAllocExistentialBoxInst(AllocExistential
 
     auto name = "ExistentialBox:" + 
       AEBI->getFormalConcreteType().getString() + "->" + AEBI->getExistentialType().getAsString();
-    SymbolTable.insert(((char *)AEBI) + 0x48 , name);
+    SymbolTable.insert(((char *)AEBI) + sizeof(SILInstruction) , name);
 
     return nullptr;
 }
@@ -455,7 +455,7 @@ jobject SILWalaInstructionVisitor::visitProjectExistentialBoxInst(ProjectExisten
     llvm::outs() << "Operand addr " << PEBI->getOperand().getOpaqueValue() << "\n";
   }
   if (SymbolTable.has(PEBI->getOperand().getOpaqueValue())) {
-    SymbolTable.duplicate(((char *)PEBI) + 0x48, SymbolTable.get(PEBI->getOperand().getOpaqueValue()).c_str());
+    SymbolTable.duplicate(((char *)PEBI) + sizeof(SILInstruction), SymbolTable.get(PEBI->getOperand().getOpaqueValue()).c_str());
   }
 
   return nullptr;


### PR DESCRIPTION
Not sure why, but it seems that adding 0x48 to the address is necessary to make it work

Implemented #29 

FOO: throw.swift@[7:17]->[7:17]
FOO: throw.swift@[8:10]->[8:10]
FOO: throw.swift@[8:10]->[8:30]
FOO: throw.swift@[8:6]->[8:6]
FOO: throw.swift@[9:8]->[9:8]
FOO: throw.swift@[9:8]->[9:8]
FOO: throw.swift@[9:8]->[9:8]
FOO: throw.swift@[9:2]->[9:8]
FOO: throw.swift@[9:2]->[9:8]
FOO: 356573597:BLOCK
  LABEL_STMT
    "BLOCK #0"
    ASSIGN
      VAR
        "ExistentialBox:VendingMachineError->$Error_0x7031c48"
      VAR
        "a_0x7031ba8"
  THROW
    VAR
      "ExistentialBox:VendingMachineError->$Error_0x7031c48"