### PR TITLE
Removed duplication of visitMetatypeInst function for WALA Support

### DIFF
--- a/include/swift/WALASupport/SILWalaInstructionVisitor.h
+++ b/include/swift/WALASupport/SILWalaInstructionVisitor.h
@@ -33,7 +33,6 @@ public:
   jobject visitProjectBoxInst(ProjectBoxInst *PBI);
   jobject visitProjectExistentialBoxInst(ProjectExistentialBoxInst *PEBI);
   jobject visitDebugValueInst(DebugValueInst *DBI);
-  jobject visitMetatypeInst(MetatypeInst *MI);
   jobject visitDebugValueAddrInst(DebugValueAddrInst *DVAI);
   jobject visitMetatypeInst(MetatypeInst *MI);
   jobject visitValueMetatypeInst(ValueMetatypeInst *VMI);

--- a/lib/WALASupport/SILWalaInstructionVisitor.cpp
+++ b/lib/WALASupport/SILWalaInstructionVisitor.cpp
@@ -550,22 +550,6 @@ jobject SILWalaInstructionVisitor::visitDebugValueAddrInst(DebugValueAddrInst *D
   return nullptr;
 }
   
-jobject SILWalaInstructionVisitor::visitMetatypeInst(MetatypeInst *MI) {
-
-  string MetatypeName = MI->getType().getAsString();
-
-  jobject NameNode = Wala->makeConstant(MetatypeName.c_str());
-  jobject MetaTypeConstNode = Wala->makeNode(CAstWrapper::CONSTANT, NameNode);
-
-  if (Print) {
-    llvm::outs() << "[Metatype]: " << MetatypeName << "\n";
-  }
-  
-  NodeMap.insert(std::make_pair(static_cast<ValueBase *>(MI), MetaTypeConstNode));
-
-  return nullptr;
-} 
-
 jobject SILWalaInstructionVisitor::visitValueMetatypeInst(ValueMetatypeInst *VMI) {
 
   auto ValueMetatypeOperand = VMI->getOperand();
@@ -594,7 +578,6 @@ jobject SILWalaInstructionVisitor::visitMetatypeInst(MetatypeInst *MI) {
     llvm::outs() << "[Metatype]: " << MetatypeName << "\n";
   }
 
-  // NodeMap.insert(std::make_pair(MI->getType().getOpaqueValue(), MetaTypeConstNode));
   NodeMap.insert(std::make_pair(static_cast<ValueBase *>(MI), MetaTypeConstNode));
 
   return nullptr;


### PR DESCRIPTION
<!-- What's in this pull request? -->
Made necessary changes to remove duplicate definition of `SILWalaInstructionVisitor:visitMetatypeInst(MetatypeInst *MI)`

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [Issue 56](https://github.com/themaplelab/swift/issues/56).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
