### PR TITLE
Modifications to SymbolTable from alloc_stack instruction visitor

### DIFF
--- a/lib/WALASupport/SILWalaInstructionVisitor.cpp
+++ b/lib/WALASupport/SILWalaInstructionVisitor.cpp
@@ -720,11 +720,22 @@ jobject SILWalaInstructionVisitor::visitAssignInst(AssignInst *AI) {
 }
 
 jobject SILWalaInstructionVisitor::visitAllocStackInst(AllocStackInst *ASI) {
-  if (Print) {
-    for (auto &OP : ASI->getAllOperands()) {
-      llvm::outs() << "\t [OPERAND]: " << OP.get() << "\n";
-      llvm::outs() << "\t [ADDR]: " << OP.get().getOpaqueValue() << "\n";
+  SILDebugVariable Info = ASI->getVarInfo();
+  unsigned ArgNo = Info.ArgNo;
+
+  if (auto *Decl = ASI->getDecl()) {
+    StringRef varName = Decl->getNameStr();
+    if (Print) {
+      llvm::outs() << "[Arg]#" << ArgNo << ":" << varName << "\n";
     }
+    SymbolTable.insert(static_cast<ValueBase *>(ASI), varName);
+  }
+  else {
+    // temporary allocation when referencing self.
+    if (Print) {
+      llvm::outs() << "[Arg]#" << ArgNo << ":" << "self" << "\n";
+    }
+    SymbolTable.insert(static_cast<ValueBase *>(ASI), "self");
   }
   return nullptr;
 }


### PR DESCRIPTION
<!-- What's in this pull request? -->
Inside the visitor function with which WALA Support for `alloc_stack` SIL instruction was provided no modification to `SymbolTable` was being made. Added those SymbolTable insertions and made some other small changes in alloc_stack visitor.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [Issue 61](https://github.com/themaplelab/swift/issues/61).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
