### PR TITLE
Support for `mark_function_escape` instruction

### DIFF
--- a/include/swift/WALASupport/SILWalaInstructionVisitor.h
+++ b/include/swift/WALASupport/SILWalaInstructionVisitor.h
@@ -56,6 +56,7 @@ public:
   jobject visitEndBorrowInst(EndBorrowInst *EBI);
   jobject visitAssignInst(AssignInst *AI);
   jobject visitMarkUninitializedInst(MarkUninitializedInst *MUI);
+  jobject visitMarkFunctionEscapeInst(MarkFunctionEscapeInst *MFEI);
   jobject visitCopyAddrInst(CopyAddrInst *CAI);
   jobject visitDestroyAddrInst(DestroyAddrInst *DAI);
   jobject visitIndexAddrInst(IndexAddrInst *IAI);

--- a/lib/WALASupport/SILWalaInstructionVisitor.cpp
+++ b/lib/WALASupport/SILWalaInstructionVisitor.cpp
@@ -590,6 +590,17 @@ jobject SILWalaInstructionVisitor::visitMarkUninitializedInst(MarkUninitializedI
   return Wala->makeNode(CAstWrapper::EMPTY);
 }
 
+jobject SILWalaInstructionVisitor::visitMarkFunctionEscapeInst(MarkFunctionEscapeInst *MFEI){
+  for(Operand &MFEOperand : MFEI->getAllOperands()){
+    unsigned OperandNumber = MFEOperand.getOperandNumber();
+    SILValue OperandValue = MFEOperand.get();
+    if (Print) {
+      llvm::outs() << "\t [OPERAND NO]: " << OperandNumber << " [VALUE]: " << OperandValue.getOpaqueValue() << "\n";
+    }
+  }
+  return Wala->makeNode(CAstWrapper::EMPTY);
+}
+
 jobject SILWalaInstructionVisitor::visitCopyAddrInst(CopyAddrInst *CAI) {
 
   SILValue Source = CAI->getSrc();


### PR DESCRIPTION
<!-- What's in this pull request? -->
Instruction Details: https://github.com/apple/swift/blob/master/docs/SIL.rst#mark_function_escape

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [Issue 146](https://github.com/themaplelab/swift/issues/146).