### PR TITLE
Move misplaced BeginUnpairedAccess and EndUnpairedAccess

### DIFF
--- a/include/swift/WALASupport/SILWalaInstructionVisitor.h
+++ b/include/swift/WALASupport/SILWalaInstructionVisitor.h
@@ -37,8 +37,6 @@ public:
   jobject visitAllocGlobalInst(AllocGlobalInst *AGI);
   jobject visitProjectBoxInst(ProjectBoxInst *PBI);
   jobject visitAllocValueBufferInst(AllocValueBufferInst *AVBI);
-  jobject visitBeginUnpairedAccessInst(BeginUnpairedAccessInst *BUI);
-  jobject visitEndUnpairedAccessInst(EndUnpairedAccessInst *EUAI);
   jobject visitProjectValueBufferInst(ProjectValueBufferInst *PVBI);
   jobject visitDeallocValueBufferInst(DeallocValueBufferInst *DVBI);
 
@@ -68,6 +66,8 @@ public:
   jobject visitTailAddrInst(TailAddrInst *TAI);
   jobject visitBeginAccessInst(BeginAccessInst *BAI);
   jobject visitEndAccessInst(EndAccessInst *EAI);
+  jobject visitBeginUnpairedAccessInst(BeginUnpairedAccessInst *BUI);
+  jobject visitEndUnpairedAccessInst(EndUnpairedAccessInst *EUAI);
 
   /*******************************************************************************/
   /*                        Reference Counting                                   */

--- a/lib/WALASupport/SILWalaInstructionVisitor.cpp
+++ b/lib/WALASupport/SILWalaInstructionVisitor.cpp
@@ -400,36 +400,6 @@ jobject SILWalaInstructionVisitor::visitAllocValueBufferInst(AllocValueBufferIns
   return  Wala->makeNode(CAstWrapper::EMPTY);
 }
 
-jobject SILWalaInstructionVisitor::visitBeginUnpairedAccessInst(BeginUnpairedAccessInst *BUI) {
-
-  SILValue SourceValue = BUI->getSource();
-  SILValue BufferValue = BUI->getBuffer();
-
-  if (Print) {
-    llvm::outs() << "\t [OPERAND]: " << SourceValue.getOpaqueValue() << "\n";
-    llvm::outs() << "\t [BUFFER]: " << SourceValue.getOpaqueValue() << "\n";
-  }
-
-  jobject SourceNode = findAndRemoveCAstNode(SourceValue.getOpaqueValue());
-
-  NodeMap.insert(std::make_pair(BufferValue.getOpaqueValue(), SourceNode));
-
-  return Wala->makeNode(CAstWrapper::EMPTY);
-}
-
-jobject SILWalaInstructionVisitor::visitEndUnpairedAccessInst(EndUnpairedAccessInst *EUAI) {
-  SILValue BufferValue = EUAI->getBuffer();
-
-  if (Print) {
-    llvm::outs() << "\t [BUFFER]: " << BufferValue << "\n";
-    llvm::outs() << "\t [BUFFER ADDR]: " << BufferValue.getOpaqueValue() << "\n";
-  }
-
-  findAndRemoveCAstNode(BufferValue.getOpaqueValue());
-
-  return Wala->makeNode(CAstWrapper::EMPTY);
-}
-
 jobject SILWalaInstructionVisitor::visitDeallocValueBufferInst(DeallocValueBufferInst *DVBI) {
   SILValue BufferValue = DVBI->getOperand();
   string ValueTypeName = DVBI->getValueType().getAsString();
@@ -787,6 +757,36 @@ jobject SILWalaInstructionVisitor::visitEndAccessInst(EndAccessInst *EAI) {
     }
     NodeMap.erase(key);
   }
+  return Wala->makeNode(CAstWrapper::EMPTY);
+}
+
+jobject SILWalaInstructionVisitor::visitBeginUnpairedAccessInst(BeginUnpairedAccessInst *BUI) {
+
+  SILValue SourceValue = BUI->getSource();
+  SILValue BufferValue = BUI->getBuffer();
+
+  if (Print) {
+    llvm::outs() << "\t [OPERAND]: " << SourceValue.getOpaqueValue() << "\n";
+    llvm::outs() << "\t [BUFFER]: " << SourceValue.getOpaqueValue() << "\n";
+  }
+
+  jobject SourceNode = findAndRemoveCAstNode(SourceValue.getOpaqueValue());
+
+  NodeMap.insert(std::make_pair(BufferValue.getOpaqueValue(), SourceNode));
+
+  return Wala->makeNode(CAstWrapper::EMPTY);
+}
+
+jobject SILWalaInstructionVisitor::visitEndUnpairedAccessInst(EndUnpairedAccessInst *EUAI) {
+  SILValue BufferValue = EUAI->getBuffer();
+
+  if (Print) {
+    llvm::outs() << "\t [BUFFER]: " << BufferValue << "\n";
+    llvm::outs() << "\t [BUFFER ADDR]: " << BufferValue.getOpaqueValue() << "\n";
+  }
+
+  findAndRemoveCAstNode(BufferValue.getOpaqueValue());
+
   return Wala->makeNode(CAstWrapper::EMPTY);
 }
 


### PR DESCRIPTION
Found 2 functions that were misplaced according to SIL.rst. They should be in `Accessing Memory`, but were in `Allocation and Deallocation`.
Issue #170